### PR TITLE
Revert "jss_changed_objects["jss_package_added"] is never populated, use jss_…"

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -496,7 +496,7 @@ class JSSImporter(Processor):
             # Passes the id of the newly created package object so JDS'
             # will upload to the correct package object. Ignored by
             # AFP/SMB.
-            if self.env["jss_changed_objects"]["jss_package_updated"]:
+            if self.env["jss_changed_objects"]["jss_package_added"]:
                 self.copy(pkg_path, id_=package.id)
             # For AFP/SMB shares, we still want to see if the package
             # exists.  If it's missing, copy it!


### PR DESCRIPTION
Reverts jssimporter/JSSImporter#125

I'm not sure, why it was changed from added to updated. The pr message says that it is never populated, but it is set when a package was added to a DP.

See also issue https://github.com/jssimporter/JSSImporter/issues/124