### PR TITLE
Fix for STOP_IF_NO_JSS_UPLOAD and #148

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -513,12 +513,15 @@ class JSSImporter(Processor):
                 return
 
             # wait for feedback that the package is there
+            timeout = time.time() + 60
             while True:
                 try:
                     package = self.jss.Package(self.pkg_name)
                     break
                 except:
-                    pass
+                    time.sleep(1)
+                    if time.time() > timeout:
+                        break
             self.output("Uploaded package id: {}".format(package.id))
 
             pkg_update = (

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -280,7 +280,7 @@ class JSSImporter(Processor):
         },
         "STOP_IF_NO_JSS_UPLOAD": {
             "required": False,
-            "default": False,
+            "default": True,
             "description":
                 ("If True, the processor will stop after verifying that "
                  "a PKG upload was not required since a PKG of the same name "

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -520,7 +520,7 @@ class JSSImporter(Processor):
                     break
                 except:
                     self.output("Waiting for package id from server...")
-                    time.sleep(1)
+                    time.sleep(5)
             self.output("Uploaded package id: {}".format(package.id))
 
             pkg_update = (

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -503,6 +503,7 @@ class JSSImporter(Processor):
 
             # only update the package object if an upload was carried out
             if self.upload_needed == False and self.env["STOP_IF_NO_JSS_UPLOAD"] == True:
+                self.output("Not overwriting policy as STOP_IF_NO_JSS_UPLOAD is set to True.")
                 return
 
             pkg_update = (self.env[

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -82,10 +82,11 @@ class JSSImporter(Processor):
                 "variable.",
         },
         "pkg_path": {
-            "required": True,
+            "required": False,
             "description":
                 "Path to a pkg or dmg to import - provided by "
                 "previous pkg recipe/processor.",
+            "default": "",
         },
         "version": {
             "required": False,

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -364,7 +364,8 @@ class JSSImporter(Processor):
         self.package = self.handle_package()
 
         # stop if no package was uploaded and STOP_IF_NO_JSS_UPLOAD is True
-        if self.env["STOP_IF_NO_JSS_UPLOAD"] and not self.upload_needed:
+        if (self.env["STOP_IF_NO_JSS_UPLOAD"] == True
+            and not self.upload_needed):
             self.summarize()
             return
 
@@ -504,7 +505,8 @@ class JSSImporter(Processor):
                 self.upload_needed = False
 
             # only update the package object if an upload was carried out
-            if self.env["STOP_IF_NO_JSS_UPLOAD"] and not self.upload_needed:
+            if (self.env["STOP_IF_NO_JSS_UPLOAD"] == True
+                and not self.upload_needed):
                 self.output("Not overwriting policy as STOP_IF_NO_JSS_UPLOAD "
                             "is set to True.")
                 self.env["stop_processing_recipe"] = True

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -363,7 +363,7 @@ class JSSImporter(Processor):
         self.package = self.handle_package()
 
         # stop if no package was uploaded and STOP_IF_NO_JSS_UPLOAD is True
-        if self.upload_needed == False and self.env["STOP_IF_NO_JSS_UPLOAD"] == True:
+        if self.env["STOP_IF_NO_JSS_UPLOAD"] and not self.upload_needed:
             self.summarize()
             return
 
@@ -503,8 +503,9 @@ class JSSImporter(Processor):
                 self.upload_needed = False
 
             # only update the package object if an upload was carried out
-            if self.upload_needed == False and self.env["STOP_IF_NO_JSS_UPLOAD"] == True:
-                self.output("Not overwriting policy as STOP_IF_NO_JSS_UPLOAD is set to True.")
+            if self.env["STOP_IF_NO_JSS_UPLOAD"] and not self.upload_needed:
+                self.output("Not overwriting policy as STOP_IF_NO_JSS_UPLOAD"
+                            "is set to True.")
                 self.env["stop_processing_recipe"] = True
                 return
 

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -514,14 +514,13 @@ class JSSImporter(Processor):
 
             # wait for feedback that the package is there
             timeout = time.time() + 60
-            while True:
+            while time.time() < timeout:
                 try:
                     package = self.jss.Package(self.pkg_name)
                     break
                 except:
+                    self.output("Waiting for package id from server...")
                     time.sleep(1)
-                    if time.time() > timeout:
-                        break
             self.output("Uploaded package id: {}".format(package.id))
 
             pkg_update = (


### PR DESCRIPTION
This adds a notification when STOP_IF_NO_JSS_UPLOAD stops the run, and adds a step that was needed to stop the run in all circumstances.

Also set the requirement of pkg_path to False, with an empty default, which fulfills #148 and the wiki statement that it should be possible to have a policy that has no package object.