### PR TITLE
Add "do_update" option for smart groups

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -1103,7 +1103,7 @@ class JSSImporter(Processor):
 
         computer_group = self.update_or_create_new(
             jss.ComputerGroup, group["template_path"],
-            update_env="jss_group_updated", added_env="jss_group_added", script_contents="")
+            update_env="jss_group_updated", added_env="jss_group_added")
 
         return computer_group
 

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -210,9 +210,10 @@ class JSSImporter(Processor):
                 "Array of group dictionaries. Wrap each group in a "
                 "dictionary. Group keys include 'name' (Name of the group to "
                 "use, required), 'smart' (Boolean: static group=False, smart "
-                "group=True, default is False, not required), and "
+                "group=True, default is False, not required), "
                 "template_path' (string: path to template file to use for "
-                "group, required for smart groups, invalid for static groups)",
+                "group, required for smart groups, invalid for static groups), "
+                "and 'do_update' (Boolean: default is True, not required)",
         },
         "exclusion_groups": {
             "required": False,
@@ -222,7 +223,8 @@ class JSSImporter(Processor):
                 "use, required), 'smart' (Boolean: static group=False, smart "
                 "group=True, default is False, not required), and "
                 "template_path' (string: path to template file to use for "
-                "group, required for smart groups, invalid for static groups)",
+                "group, required for smart groups, invalid for static groups), "
+                "and 'do_update' (Boolean: default is True, not required)",
         },
         "scripts": {
             "required": False,
@@ -605,6 +607,7 @@ class JSSImporter(Processor):
         computer_groups = []
         if groups:
             for group in groups:
+                self.output("Computer Group to process: %s" % group["name"])
                 if self.validate_input_var(group):
                     is_smart = group.get("smart", False)
                     if is_smart:
@@ -856,6 +859,8 @@ class JSSImporter(Processor):
             update_env: The environment var to update if an object is
                 updated.
             script_contents (str): XML escaped script.
+            do_update (Boolean): Do not overwrite an existing group if
+                set to False.
 
         Returns:
             The recipe object after updating.
@@ -943,7 +948,7 @@ class JSSImporter(Processor):
         """Return an object based on a template located in search path.
 
         Args:
-            obj_cls: JSSObject class (for the purposes of JSSIMporter a
+            obj_cls: JSSObject class (for the purposes of JSSImporter a
                 Policy or a ComputerGroup)
             template_path: String filename or path to template file.
                 See find_file_in_search_path() for more information on
@@ -1067,8 +1072,9 @@ class JSSImporter(Processor):
         # Does the group have a blank value? (A blank value isn't really
         # invalid, but there's no need to process it further.)
         invalid = [False for value in var.values() if isinstance(value, str)
-                   and (value.startswith("%") and value.endswith("%")) or not
-                   value]
+                   and (value.startswith("%") and value.endswith("%"))]
+        if not var.get('name') or not var.get('template_path'):
+            invalid = True
         return False if invalid else True
 
     def add_or_update_smart_group(self, group):
@@ -1079,6 +1085,22 @@ class JSSImporter(Processor):
             self.replace_dict["site_id"] = group.get("site_id")
         if group.get("site_name"):
             self.replace_dict["site_name"] = group.get("site_name")
+
+        # If do_update is set to False, do not update this object
+        do_update = group.get("do_update", True)
+        if not do_update:
+            try:
+                computer_group = self.jss.ComputerGroup(group["name"])
+                self.output("Computer Group: %s already exists "
+                            "and set not to update." %
+                            computer_group.name)
+                return computer_group
+            except jss.GetError:
+                self.output("Computer Group: %s does not already exist. "
+                            "Creating from template." %
+                            group["name"])
+                pass
+
         computer_group = self.update_or_create_new(
             jss.ComputerGroup, group["template_path"],
             update_env="jss_group_updated", added_env="jss_group_added")

--- a/pkg/jssimporter/build-info.plist
+++ b/pkg/jssimporter/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>1.0.2b3</string>
+	<string>1.0.2b4</string>
 </dict>
 </plist>


### PR DESCRIPTION
The `do_update` parameter is an optional addition to the `groups` and `exclusion_groups` dictionaries within the arguments of a JSS recipe. This allows the recipe to specify a computer group to be added to the Targets and Exclusions of a policy, but not to update the smart groups if they already exist. The default behaviour is `do_update == True`, which is the same as the current behaviour. If `<key>do_update</key><false/>` is added to a group dictionary, an existing group of the specifying name will not be overwritten/updated.

The use case for this change is that an administrator can automatically provide smart groups via AutoPkg, which can then be altered - most likely, the criteria is changed. More broadly, the idea is that JSSImporter can be used to create a set of production policies for a software title, some of which will change with new software versions, but some will not, and need to have adjustable scope.

Example:
```
<key>groups</key>
<array>
	<dict>
		<key>do_update</key>
		<false/>
		<key>name</key>
		<string>%USERS_GROUP_NAME%</string>
		<key>smart</key>
		<true/>
		<key>template_path</key>
		<string>%USERS_GROUP_TEMPLATE%</string>
	</dict>
</array>
```
