### PR TITLE
Add skip_scripts option

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -296,6 +296,11 @@ class JSSImporter(Processor):
                  "and policy updates are coupled together. This allows group "
                  "updates without updating or overwriting policy scope."),
         },
+        "skip_scripts": {
+            "required": False,
+            "default": False,
+            "description": "If True, policy scripts will not be updated.",
+        },
     }
     output_variables = {
         "jss_changed_objects": {
@@ -920,7 +925,8 @@ class JSSImporter(Processor):
             # If skip_scope is True then don't include scope data.
             if self.env["skip_scope"] is not True:
                 self.add_scope_to_policy(recipe_object)
-            self.add_scripts_to_policy(recipe_object)
+            if self.env["skip_scripts"] is not True:
+                self.add_scripts_to_policy(recipe_object)
             self.add_package_to_policy(recipe_object)
 
         # If object is a script, add the passed contents to the object.


### PR DESCRIPTION
Add skip_scripts input variable. If True, policy scripts will not be modified. Useful for situations where a policy has a package and script, but you don't want to script to be overwritten when not managed with JSSImporter.