### PR TITLE
Fix for policy category with ampersand in name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .ropeproject
 *.pkg
 *.DS_Store
+local_tests/*

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -24,6 +24,7 @@ from collections import OrderedDict
 from distutils.version import StrictVersion
 from zipfile import ZipFile, ZIP_DEFLATED
 from xml.etree import ElementTree
+from xml.sax.saxutils import escape
 
 sys.path.insert(0, '/Library/Application Support/JSSImporter')
 
@@ -908,7 +909,7 @@ class JSSImporter(Processor):
                 if policy_category is None:
                     policy_category = ElementTree.SubElement(
                         recipe_object, "category")
-                    policy_category.text = self.env.get('policy_category')
+                policy_category.text = self.env.get('policy_category')
 
             if existing_object is not None:
                 # If this policy already exists, and it has an icon set,
@@ -1052,7 +1053,8 @@ class JSSImporter(Processor):
         return final_path
 
     def replace_text(self, text, replace_dict):   # pylint: disable=no-self-use
-        """Substitute items in a text string.
+        """Substitute items in a text string. Also escapes for XML,
+        as this is the only use for this definition
 
         Args:
             text: A string with embedded %tags%.
@@ -1065,7 +1067,9 @@ class JSSImporter(Processor):
         """
         for key, value in replace_dict.iteritems():
             # Wrap our keys in % to match template tags.
+            value = escape(value)
             text = text.replace("%%%s%%" % key, value)
+
         return text
 
     def validate_input_var(self, var):   # pylint: disable=no-self-use


### PR DESCRIPTION
This fixes issue #160, the problem of an `not well-formed (invalid token): line X, column Y` error if any of the input keys contain characters that should be XML escaped. This includes `POLICY_CATEGORY`, `SELF_SERVICE_DESCRIPTION`, `PROD_NAME` etc.

It may also prevent the problem of category not being assigned to policies. There was what appears to be an indentation error in this section.